### PR TITLE
fix: Cannot find module '@vite-pwa/sveltekit' issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./dist/*"
+        "./dist/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
typesVersions of package.json now includes only type def file, which fixes the below issue
<img width="1032" alt="Screenshot 2022-12-21 at 1 04 04 PM" src="https://user-images.githubusercontent.com/34126474/208849545-cb1b5a43-7c40-4e97-8964-10c06aed633c.png">
