### PR TITLE
fixed:  .html suffix is missing of url in service worker js file

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,7 @@ function createManifestTransform(base: string, options?: KitOptions): ManifestTr
         if (url.startsWith('/'))
           url = url.slice(1)
 
-        e.url = url === 'index.html' ? `${base}` : `${base}${url.slice(0, url.lastIndexOf('.'))}${suffix}`
+        e.url = url === "index.html" ? `${base}` : `${base}${url}`;
       }
       else {
         e.url = url


### PR DESCRIPTION
suffix is empty, index.html of subdirectory will miss .html suffix in service-worker javascript file.