### PR TITLE
feat: allow configure falsy navigate fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/sveltekit",
   "type": "module",
   "version": "0.2.7",
-  "packageManager": "pnpm@8.8.0",
+  "packageManager": "pnpm@8.10.3",
   "description": "Zero-config PWA for SvelteKit",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,8 @@ export function configureSvelteKitOptions(
   }
   else {
     options.workbox = options.workbox ?? {}
-    if (!options.workbox.navigateFallback)
+    // the user may want to disable offline support
+    if (!('navigateFallback' in options.workbox))
       options.workbox.navigateFallback = adapterFallback ?? base
 
     config = options.workbox


### PR DESCRIPTION
When using generate strategy and providing navigateFallback with null or undefined, the module will change the value to the base